### PR TITLE
fix: usage of client instead of api

### DIFF
--- a/client-api/events.md
+++ b/client-api/events.md
@@ -33,10 +33,10 @@ Check for a specific on-chain event or event record.
 const records = await client.query.system.events();
 
 const instantiatedEvent = records.map(({ event }) => event)
-                                .find(api.events.contracts.Instantiated.is); // narrow down the type for type suggestions
+                                .find(client.events.contracts.Instantiated.is); // narrow down the type for type suggestions
                                 
 // OR
-const instantiatedEventRecord = records.find(api.events.contracts.Instantiated.is);
+const instantiatedEventRecord = records.find(client.events.contracts.Instantiated.is);
 ```
 
 #### find
@@ -46,7 +46,7 @@ Find an on-chain event from a list of system event records.
 ```typescript
 const records = await client.query.system.events();
 
-const instantiatedEvent = api.events.contracts.Instantiated.find(records);
+const instantiatedEvent = client.events.contracts.Instantiated.find(records);
 ```
 
 #### filter
@@ -56,5 +56,5 @@ Return a list of a specific on-chain event from a list of system event records.
 ```typescript
 const records = await client.query.system.events();
 
-const instantiatedEvents = api.events.contracts.Instantiated.filter(records);
+const instantiatedEvents = client.events.contracts.Instantiated.filter(records);
 ```

--- a/client-api/transactions.md
+++ b/client-api/transactions.md
@@ -2,7 +2,7 @@
 
 Transaction apis are designed to be compatible with [`IKeyringPair`](https://github.com/polkadot-js/api/blob/3bdf49b0428a62f16b3222b9a31bfefa43c1ca55/packages/types/src/types/interfaces.ts#L15-L21) and [`Signer`](https://github.com/polkadot-js/api/blob/3bdf49b0428a62f16b3222b9a31bfefa43c1ca55/packages/types/src/types/extrinsic.ts#L135-L150) interfaces, so you can sign the transactions with accounts created by a [`Keyring`](https://github.com/polkadot-js/common/blob/22aab4a4e62944a2cf8c885f50be2c1b842813ec/packages/keyring/src/keyring.ts#L41-L40) or from any [Polkadot{.js}-based](https://github.com/polkadot-js/extension?tab=readme-ov-file#api-interface) wallet extensions.
 
-All transaction apis are exposed in `ChainApi` interface and can be access with syntax: `api.tx.<pallet>.<transactionName>`. E.g: Available transaction apis for Polkadot network are defined [here](https://github.com/dedotdev/chaintypes/blob/main/packages/chaintypes/src/polkadot/tx.d.ts), similarly for other networks as well.
+All transaction apis are exposed in `ChainApi` interface and can be access with syntax: `client.tx.<pallet>.<transactionName>`. E.g: Available transaction apis for Polkadot network are defined [here](https://github.com/dedotdev/chaintypes/blob/main/packages/chaintypes/src/polkadot/tx.d.ts), similarly for other networks as well.
 
 ### Sign & send a transaction
 


### PR DESCRIPTION
This PR fixes a typo in which `api` is used instead of `client`.